### PR TITLE
Add auto publish to npm action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,39 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  # Test should have passed before this job is manually triggered
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
+      # this step. Subsequent steps can then access the value
+      - name: Read Node version
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        # Give the step an ID to make it easier to refer to
+        id: nvm
+
+      # Gets the version to use by referring to the previous step
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          registry-url: https://registry.npmjs.org/
+
+      # Performs a clean installation of all dependencies in the `package.json` file
+      # For more information, see https://docs.npmjs.com/cli/ci.html
+      - name: Install dependencies
+        run: npm ci
+
+      # Create the package and push to https://www.npmjs.com/
+      - name: Publish package
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.WATER_NPM_TOKEN}}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3847

We recently had an issue with releasing [water-abstraction-helpers](https://github.com/DEFRA/water-abstraction-helpers/commit/f36eec68f57ec075eeb1c8131576870cf9abc87c) that meant we couldn't push new versions to NPM.

We assumed the same issue would be present in this repo but have found it doesn't have the same facility to automatically publish new releases.

They should be set up the same way so we don't have 2 different processes for doing the same thing. This change adds the same GitHub action **water-abstraction-helpers** uses to automate the process for us.