### PR TITLE
Remove verbose from db migrate commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "WRLS service team",
   "license": "OGL-UK-3.0",
   "scripts": {
-    "migrate": "node node_modules/db-migrate/bin/db-migrate up --verbose",
+    "migrate": "node node_modules/db-migrate/bin/db-migrate up",
     "lint": "standard",
     "test": "lab",
     "test:bail": "lab --bail",


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/65

We needed to add a large data migration to fix an issue. The fix worked but it broke CI. GitHub actions started erroring when the migrations ran with `##[error]stderr maxBuffer length exceeded`.

Unlike locally, where only the latest migrations are run, in CI all migrations are run all the time and our 2.5k SQL script (😳 😁 ) was obviously the straw that broke the camel's back.

We realised that so much was outputting because all our migration scripts have the `--verbose` flag set. When we removed it in this case, the problem was solved.

We don't need to see it, and it might avoid the same problem from happening to other repos. So, this issue is about going through the repos and removing `--verbose` from any migrate commands.