### PR TITLE
Removing console.log() from legacy migrations

### DIFF
--- a/migrations/20180111093803-create-table.js
+++ b/migrations/20180111093803-create-table.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180122170909-add-auto-pk-table.js
+++ b/migrations/20180122170909-add-auto-pk-table.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180306114914-add-email-field.js
+++ b/migrations/20180306114914-add-email-field.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180307100006-numeric-primary-key.js
+++ b/migrations/20180307100006-numeric-primary-key.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180406144545-json-field-type.js
+++ b/migrations/20180406144545-json-field-type.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/91

This PR is focusing on removing console.log() from legacy migrations as per Teams issue. When working on DEFRA/water-abstraction-service#2227 we again broke GitHub CI because of the volume of output from our migrations.

In DEFRA/water-abstraction-team#65 we thought we'd dealt with the issue believing that db-mgrate's verbose() argument was to blame.

Looking into the issue in the stuck bill run we came across a db-migrate/node-db-migrate#453 (comment) that gave us a 🤦 !

The db-migrate template used when generating migrations includes a console.log() that outputs the migration file read in. So, though we might not be outputting all the SQL being fired, we are still outputting the contents of every single migration file!

We definitely don't need to see this and it should remove the chance of us breaking the build in this way once and for all.

So, this issue is about going into the existing migrations and removing the 2 console.log('received data: ' + data) lines in each across all repos.