### PR TITLE
Add an npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "allowScripts": {
+    "ssh2@1.4.0": true
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5680

**Why we're making this change**

- npm is moving to stop running install scripts (`preinstall`/`install`/`postinstall`) from third-party dependencies by default, to cut supply-chain risk from compromised packages. This lands via the new `allowScripts` policy / `npm approve-scripts` command, already opt-in from npm 11.16.0 and due to become the v12 default (~July 2026) — see [Upcoming breaking changes for npm v12](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/) and [npm-approve-scripts docs](https://docs.npmjs.com/cli/v11/commands/npm-approve-scripts).
- `min-release-age=7` gives us equivalent protection now, ahead of that rollout, by refusing to install a dependency version published less than 7 days ago ([reference](https://gist.github.com/mcollina/b294a6c39ee700d24073c0e5a4e93104)).
- `save-exact=true` pins exact dependency versions rather than ranges.

**Why we're not also setting `ignore-scripts=true`**

- `ignore-scripts=true` disables *all* lifecycle scripts, including our own — it could break scripts this package relies on (e.g. `pretest`/`postinstall`).
- The incoming npm v12 default only restricts scripts from dependencies, not our own package's scripts, so it already gives us the protection we want here without that side effect. Adding `ignore-scripts=true` ourselves isn't necessary.
